### PR TITLE
Revert "Bump pytest from 8.0.2 to 8.1.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,7 @@ dev = [
     "pyproject-fmt==1.7.0",
     "pyright==1.1.352",
     "pyroma==4.2",
-    "pytest==8.1.0",
+    "pytest==8.0.2",
     "pytest-cov==4.1",
     "PyYAML==6.0.1",
     "ruff==0.3.0",


### PR DESCRIPTION
Reverts VWS-Python/vws-python#2144

8.1.0 has been yanked