### PR TITLE
Remove sphinx-prompt dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
-    "sphinx-prompt",
     "sphinx_substitution_extensions",
     "sphinxcontrib.spelling",
 ]

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -10,39 +10,39 @@ Install contribution dependencies
 
 Install Python dependencies in a virtual environment.
 
-.. prompt:: bash
+.. code-block:: console
 
-   pip install --editable '.[dev]'
+   $ pip install --editable '.[dev]'
 
 Spell checking requires ``enchant``.
 This can be installed on macOS, for example, with `Homebrew`_:
 
-.. prompt:: bash
+.. code-block:: console
 
-   brew install enchant
+   $ brew install enchant
 
 and on Ubuntu with ``apt``:
 
-.. prompt:: bash
+.. code-block:: console
 
-   apt-get install -y enchant
+   $ apt-get install -y enchant
 
 Install ``pre-commit`` hooks:
 
-.. prompt:: bash
+.. code-block:: console
 
-   pre-commit install
+   $ pre-commit install
 
 Linting
 -------
 
 Run lint tools either by committing, or with:
 
-.. prompt:: bash
+.. code-block:: console
 
-   pre-commit run --all-files --hook-stage commit --verbose
-   pre-commit run --all-files --hook-stage push --verbose
-   pre-commit run --all-files --hook-stage manual --verbose
+   $ pre-commit run --all-files --hook-stage commit --verbose
+   $ pre-commit run --all-files --hook-stage push --verbose
+   $ pre-commit run --all-files --hook-stage manual --verbose
 
 .. _Homebrew: https://brew.sh
 
@@ -51,9 +51,9 @@ Running tests
 
 Run ``pytest``:
 
-.. prompt:: bash
+.. code-block:: console
 
-   pytest
+   $ pytest
 
 Documentation
 -------------
@@ -62,10 +62,10 @@ Documentation is built on Read the Docs.
 
 Run the following commands to build and view documentation locally:
 
-.. prompt:: bash
+.. code-block:: console
 
-   make docs
-   make open-docs
+   $ make docs
+   $ make open-docs
 
 Continuous integration
 ----------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,9 +4,9 @@
 Installation
 ------------
 
-.. prompt:: bash
+.. code-block:: console
 
-   pip3 install vws-python
+   $ pip install vws-python
 
 This is tested on Python 3.8+.
 Get in touch with ``adamdangoor@gmail.com`` if you would like to use this with another language.
@@ -90,9 +90,9 @@ Testing
 
 To write unit tests for code which uses this library, without using your Vuforia quota, you can use the `VWS Python Mock`_ tool:
 
-.. prompt:: bash
+.. code-block:: console
 
-   pip3 install vws-python-mock
+   $ pip install vws-python-mock
 
 .. clear-namespace
 

--- a/docs/source/release-process.rst
+++ b/docs/source/release-process.rst
@@ -14,9 +14,9 @@ Perform a Release
 
 #. Perform a release:
 
-   .. prompt:: bash
+   .. code-block:: console
       :substitutions:
 
-      gh workflow run release.yml --repo |github-owner|/|github-repository|
+      $ gh workflow run release.yml --repo |github-owner|/|github-repository|
 
 .. _Install GitHub CLI: https://cli.github.com/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ optional-dependencies.dev = [
     "pyyaml==6.0.1",
     "ruff==0.5.5",
     "sphinx==7.4.7",
-    "sphinx-prompt==1.8",
     "sphinx-substitution-extensions==2024.2.25",
     "sphinxcontrib-spelling==8",
     "sybil==6.1.1",


### PR DESCRIPTION
It is no longer needed for my purposes, and it is not yet supported on Sphinx 8.