### PR TITLE
Adopt vws-test-fixtures 2026.8.23 boundary fixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ optional-dependencies.dev = [
     "vale==3.13.0.0",
     "vulture==2.16",
     "vws-python-mock==2026.8.14",
-    "vws-test-fixtures==2026.8.16",
+    "vws-test-fixtures==2026.8.23",
     "yamlfix==1.19.1",
     "zizmor==1.29.0",
 ]

--- a/tests/test_async_cloud_reco_exceptions.py
+++ b/tests/test_async_cloud_reco_exceptions.py
@@ -53,7 +53,7 @@ async def test_too_many_max_results(
 async def test_image_too_large(
     *,
     async_cloud_reco_client: AsyncCloudRecoService,
-    png_too_large: io.BytesIO | io.BufferedRandom,
+    jpeg_too_large: io.BytesIO | io.BufferedRandom,
 ) -> None:
     """A ``RequestEntityTooLarge`` exception is raised if an
     image which is too large is given.
@@ -62,7 +62,7 @@ async def test_image_too_large(
         expected_exception=RequestEntityTooLargeError,
     ) as exc:
         await async_cloud_reco_client.query(
-            image=png_too_large,
+            image=jpeg_too_large,
         )
 
     assert (

--- a/tests/test_async_vws_exceptions.py
+++ b/tests/test_async_vws_exceptions.py
@@ -1,5 +1,6 @@
 """Tests for VWS exceptions raised from async clients."""
 
+import base64
 import io
 import uuid
 from http import HTTPStatus
@@ -312,10 +313,17 @@ async def test_metadata_too_large(
     *,
     async_vws_client: AsyncVWS,
     high_quality_image: io.BytesIO,
+    application_metadata_near_size_limit: str,
 ) -> None:
     """A ``MetadataTooLarge`` exception is raised if the metadata
     given is too large.
     """
+    decoded_metadata = base64.b64decode(
+        s=application_metadata_near_size_limit.encode(encoding="ascii"),
+    )
+    over_limit_metadata = base64.b64encode(
+        s=decoded_metadata + b"x",
+    ).decode(encoding="ascii")
     with pytest.raises(
         expected_exception=MetadataTooLargeError,
     ) as exc:
@@ -324,7 +332,7 @@ async def test_metadata_too_large(
             width=1,
             image=high_quality_image,
             active_flag=True,
-            application_metadata="a" * 1024 * 1024 * 10,
+            application_metadata=over_limit_metadata,
         )
 
     assert exc.value.response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/tests/test_cloud_reco_exceptions.py
+++ b/tests/test_cloud_reco_exceptions.py
@@ -49,7 +49,7 @@ def test_too_many_max_results(
 def test_image_too_large(
     *,
     cloud_reco_client: CloudRecoService,
-    png_too_large: io.BytesIO | io.BufferedRandom,
+    jpeg_too_large: io.BytesIO | io.BufferedRandom,
 ) -> None:
     """
     A ``RequestEntityTooLarge`` exception is raised if an image which is
@@ -57,7 +57,7 @@ def test_image_too_large(
     large is given.
     """
     with pytest.raises(expected_exception=RequestEntityTooLargeError) as exc:
-        cloud_reco_client.query(image=png_too_large)
+        cloud_reco_client.query(image=jpeg_too_large)
 
     assert (
         exc.value.response.status_code == HTTPStatus.REQUEST_ENTITY_TOO_LARGE

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -1,5 +1,6 @@
 """Tests for VWS exceptions."""
 
+import base64
 import io
 import uuid
 from http import HTTPStatus
@@ -297,19 +298,26 @@ def test_metadata_too_large(
     *,
     vws_client: VWS,
     high_quality_image: io.BytesIO,
+    application_metadata_near_size_limit: str,
 ) -> None:
     """
     A ``MetadataTooLarge`` exception is raised if the metadata given is
     too
     large.
     """
+    decoded_metadata = base64.b64decode(
+        s=application_metadata_near_size_limit.encode(encoding="ascii"),
+    )
+    over_limit_metadata = base64.b64encode(
+        s=decoded_metadata + b"x",
+    ).decode(encoding="ascii")
     with pytest.raises(expected_exception=MetadataTooLargeError) as exc:
         vws_client.add_target(
             name="x",
             width=1,
             image=high_quality_image,
             active_flag=True,
-            application_metadata="a" * 1024 * 1024 * 10,
+            application_metadata=over_limit_metadata,
         )
 
     assert exc.value.response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
## Summary
- Bump `vws-test-fixtures` to 2026.8.23
- Use `jpeg_too_large` for Cloud Recognition `RequestEntityTooLarge` tests
- Derive over-limit metadata from `application_metadata_near_size_limit`

Fixes #3160

## Test plan
- [x] `test_cloud_reco_exceptions.py::test_image_too_large`
- [x] `test_async_cloud_reco_exceptions.py::test_image_too_large`
- [x] `test_vws_exceptions.py::test_metadata_too_large`
- [x] `test_async_vws_exceptions.py::test_metadata_too_large`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture bump and exception-test updates; no production or security-sensitive code changes.
> 
> **Overview**
> Bumps `vws-test-fixtures` to `2026.8.23` and uses its new boundary fixtures in exception tests.
> 
> Cloud Recognition `RequestEntityTooLarge` tests now query with `jpeg_too_large` instead of `png_too_large`. `MetadataTooLarge` tests build over-limit metadata from `application_metadata_near_size_limit` instead of a hardcoded oversized string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0e6b2b9eac35bb10c60e76ad72334e6c41e5bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->