### PR TITLE
Make towncrier fail on invalid news fragment suffixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,6 +434,11 @@ issue_format = "#{issue}"
 # version such as ``2026.05.18`` underlined with ``-`` matches every
 # pre-towncrier entry in CHANGELOG.rst.
 underlines = [ "-", "~", "^" ]
+# Setting ``ignore`` makes ``towncrier build`` fail on any file in
+# the fragment directory whose suffix is not a declared fragment
+# type, instead of silently dropping it.  Only the listed
+# non-fragment files are allowed through.
+ignore = [ ".gitkeep" ]
 type = [
     # A single, unnamed fragment type keeps the assembled output as one
     # flat bullet list, matching the historical changelog (which never


### PR DESCRIPTION
## Summary

- configure Towncrier to allow only `.gitkeep` as a non-fragment file
- make invalid fragment suffixes fail the changelog build

## Verification

- `towncrier==25.8.0` builds the current fragments in draft mode
- an added `999999.invalid` fragment fails with `Invalid news fragment name`
- repository pre-commit and pre-push hooks passed

Closes #3175