### PR TITLE
Make pyrefly error on unused ignore comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,6 +405,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
+errors.unused-ignore = "error"
 
 [tool.pyright]
 typeCheckingMode = "strict"


### PR DESCRIPTION
Sets `errors.unused-ignore = "error"` in the pyrefly config. This rule is silent by default (not even a warning), so `# pyrefly: ignore` comments that no longer suppress anything go unnoticed after pyrefly upgrades. Same change as VWS-Python/vws-python-mock#3567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)