### PR TITLE
Use the pyrefly strict preset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -405,7 +405,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
-errors.unused-ignore = "error"
+preset = "strict"
 
 [tool.pyright]
 typeCheckingMode = "strict"


### PR DESCRIPTION
Switches the pyrefly config to `preset = "strict"` (see https://pyrefly.org/en/docs/configuration/). Strict enables `unused-ignore`, so stale `# pyrefly: ignore` comments fail the check, along with `implicit-any`, `missing-override-decorator` and others. Any new errors from the stricter checks are fixed in this PR. Same change as VWS-Python/vws-python-mock#3567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)