### PR TITLE
Use Ty's strictest recommended configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ line-length = 79
 lint.select = [
     "ALL",
 ]
+lint.extend-select = [ "ANN", "PGH003", "PYI" ]
 lint.ignore = [
     # Ruff warns that this conflicts with the formatter.
     "COM812",
@@ -135,6 +136,7 @@ lint.ignore = [
     # helping.
     "PLR0913",
 ]
+lint.explicit-preview-rules = true
 lint.per-file-ignores."doccmd_*.py" = [
     # Allow asserts in docs.
     "S101",
@@ -158,6 +160,7 @@ lint.flake8-tidy-imports.banned-api."typing.cast".msg = """\
     typing.cast is banned: use explicit type narrowing or a typed variable instead.\
     """
 lint.pydocstyle.convention = "google"
+lint.preview = true
 
 [tool.pylint]
 # Disable the message, report, category or checker with the given id(s). You
@@ -404,6 +407,23 @@ preset = "all"
 typeCheckingMode = "strict"
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
+
+[tool.ty]
+rules.blanket-ignore-comment = "error"
+rules.division-by-zero = "warn"
+rules.dynamic-function-decorator-return = "error"
+rules.missing-type-argument = "error"
+rules.possibly-missing-attribute = "warn"
+rules.possibly-missing-import = "warn"
+rules.possibly-unresolved-reference = "warn"
+rules.unsound-assignment = "error"
+rules.unsound-return-statement = "error"
+rules.unsound-yield = "error"
+rules.unsupported-dynamic-base = "warn"
+terminal.error-on-warning = true
+analysis.respect-type-ignore-comments = false
+analysis.strict-equality-semantics = true
+analysis.strict-generic-narrowing = true
 
 [tool.pytest]
 log_cli = true

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -111,6 +111,7 @@ todo
 traceback
 travis
 txt
+ty
 unmocked
 untyped
 url

--- a/src/vws/_model_targets.py
+++ b/src/vws/_model_targets.py
@@ -84,7 +84,7 @@ def access_token_from_response(*, response: Response) -> tuple[str, float]:
         raise ModelTargetOAuth2Error(response=response)
 
     response_data = dict(json.loads(s=response.text))
-    return response_data["access_token"], float(response_data["expires_in"])
+    return response_data["access_token"], float(response_data["expires_in"])  # ty: ignore[unsound-return-statement]
 
 
 @beartype(conf=BeartypeConf(is_pep484_tower=True))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,7 +225,7 @@ def fixture_image_file(
     file = tmp_path / "image.jpg"
     buffer = high_quality_image.getvalue()
     _ = file.write_bytes(data=buffer)
-    mode: Literal["r+b", "rb"] = request.param
+    mode: Literal["r+b", "rb"] = request.param  # ty: ignore[unsound-assignment]
     with file.open(mode=mode) as file_obj:
         yield file_obj
 


### PR DESCRIPTION
## Summary

- enable Astral's strictest recommended Ty rules and analysis semantics
- enable the recommended Ruff ANN, PYI, and PGH003 families
- keep preview rules explicit so existing select-all configurations do not activate unrelated preview diagnostics
- narrow straightforward typed collections and use diagnostic-specific Ty suppressions at intentionally untyped framework/data boundaries

Configuration reference: https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#recommended-configuration

## Validation

- ty check
- ruff check .
- full pre-commit hook suite
