### PR TITLE
Configure checker-specific ignore comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,6 +401,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
+enabled-ignores = [ "pyrefly" ]
 preset = "all"
 
 [tool.pyright]


### PR DESCRIPTION
Configure Pyrefly to accept only `# pyrefly: ignore` comments. This keeps Mypy `# type: ignore` comments foreign to Pyrefly while `preset = "all"` continues to reject stale Pyrefly suppressions.