### PR TITLE
Use one sentence per line in documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,14 @@ Changelog
 2026.09.07
 ----------
 
-- Add ``HTTPX2Transport`` and ``AsyncHTTPX2Transport``, which make requests with ``httpx2``, the continuation of ``httpx`` maintained by Pydantic. The ``requests`` and ``httpx`` transports are unchanged. ``httpx`` and ``httpx2`` objects are never mixed: the ``httpx`` transports raise ``httpx`` exceptions and the ``httpx2`` transports raise ``httpx2`` exceptions.
+- Add ``HTTPX2Transport`` and ``AsyncHTTPX2Transport``, which make requests with ``httpx2``, the continuation of ``httpx`` maintained by Pydantic.
+  The ``requests`` and ``httpx`` transports are unchanged.
+  ``httpx`` and ``httpx2`` objects are never mixed: the ``httpx`` transports raise ``httpx`` exceptions and the ``httpx2`` transports raise ``httpx2`` exceptions.
 
 2026.08.26
 ----------
 
-- Test synchronous and asynchronous Model Target error responses through the
-  public mock API, and include rate-limit and server-error branches in coverage.
+- Test synchronous and asynchronous Model Target error responses through the public mock API, and include rate-limit and server-error branches in coverage.
 
 2026.08.14
 ----------
@@ -30,7 +31,8 @@ Changelog
 - Add support for the Model Target Web API.
   ``ModelTargetService`` and ``AsyncModelTargetService`` create standard and advanced Model Target datasets, wait for them to be generated, download them and delete them.
 
-- Map the ``ProjectHasNoApiAccess`` result code, as spelled in Vuforia's result codes table, to ``ProjectHasNoAPIAccessError``. The previously mapped ``ProjectHasNoAPIAccess`` casing, which Vuforia does not document, is no longer mapped.
+- Map the ``ProjectHasNoApiAccess`` result code, as spelled in Vuforia's result codes table, to ``ProjectHasNoAPIAccessError``.
+  The previously mapped ``ProjectHasNoAPIAccess`` casing, which Vuforia does not document, is no longer mapped.
 
 - Add support for the Database Reco Counts report.
   ``VWS`` and ``AsyncVWS`` take an optional ``database_id``, and have new ``request_database_reco_counts_report``, ``download_reco_counts_report`` and ``wait_for_reco_counts_report`` methods.
@@ -63,7 +65,9 @@ Changelog
 ----------
 
 
-* Add ``request_timeout_seconds`` parameter to ``VWS`` and ``CloudRecoService``, allowing customization of the request timeout. This accepts a float or a ``(connect, read)`` tuple, matching the ``requests`` library's timeout interface. The default remains 30 seconds.
+* Add ``request_timeout_seconds`` parameter to ``VWS`` and ``CloudRecoService``, allowing customization of the request timeout.
+  This accepts a float or a ``(connect, read)`` tuple, matching the ``requests`` library's timeout interface.
+  The default remains 30 seconds.
 
 2025.03.10.1
 ------------
@@ -154,9 +158,7 @@ Changelog
 ------------
 
 * Breaking change: Move exceptions and create base exceptions.
-  It is now possible to, for example, catch
-  ``vws.exceptions.base_exceptions.VWSException`` to catch many of the
-  exceptions raised by the ``VWS`` client.
+  It is now possible to, for example, catch ``vws.exceptions.base_exceptions.VWSException`` to catch many of the exceptions raised by the ``VWS`` client.
   Credit to ``@laymonage`` for this change.
 
 2020.08.21.0

--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -11,19 +11,9 @@ Our Standards
 
 Examples of behavior that contributes to creating a positive environment include:
 
-Using welcoming and inclusive language
-Being respectful of differing viewpoints and experiences
-Gracefully accepting constructive criticism
-Focusing on what is best for the community
-Showing empathy towards other community members
-Examples of unacceptable behavior by participants include:
+Using welcoming and inclusive language Being respectful of differing viewpoints and experiences Gracefully accepting constructive criticism Focusing on what is best for the community Showing empathy towards other community members Examples of unacceptable behavior by participants include:
 
-The use of sexualized language or imagery and unwelcome sexual attention or advances
-Trolling, insulting/derogatory comments, and personal or political attacks
-Public or private harassment
-Publishing others' private information, such as a physical or electronic address, without explicit permission
-Other conduct which could reasonably be considered inappropriate in a professional setting
-Our Responsibilities
+The use of sexualized language or imagery and unwelcome sexual attention or advances Trolling, insulting/derogatory comments, and personal or political attacks Public or private harassment Publishing others' private information, such as a physical or electronic address, without explicit permission Other conduct which could reasonably be considered inappropriate in a professional setting Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
@@ -32,12 +22,17 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 Scope
 -----
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+Representation of a project may be further defined and clarified by project maintainers.
 
 Enforcement
 -----------
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at adamdangoor@gmail.com. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at adamdangoor@gmail.com.
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,7 @@
 vws-python
 ==========
 
-Python library for the Vuforia Web Services (VWS) API and the Vuforia
-Web Query API.
+Python library for the Vuforia Web Services (VWS) API and the Vuforia Web Query API.
 
 Installation
 ------------
@@ -13,9 +12,8 @@ Installation
 
    pip install vws-python
 
-This is tested on Python |minimum-python-version|\+. Get in touch with
-``adamdangoor@gmail.com`` if you would like to use this with another
-language.
+This is tested on Python |minimum-python-version|\+.
+Get in touch with ``adamdangoor@gmail.com`` if you would like to use this with another language.
 
 Getting Started
 ---------------


### PR DESCRIPTION
## Summary

- Reflow Markdown and reStructuredText prose so each sentence occupies one source line.
- Preserve tables, directives, code blocks, and vendored content.

## Validation
- Pinned Vale prose check
- Pandoc render-equivalence comparison
- git diff --check