### PR TITLE
Remove supported runtime-import suppressions

### DIFF
--- a/newsfragments/3216.change.rst
+++ b/newsfragments/3216.change.rst
@@ -1,0 +1,1 @@
+Remove supported inline type-checking comments by teaching Ruff about runtime-evaluated ``beartype`` annotations and postponing test annotations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ lint.flake8-tidy-imports.banned-api."operator.attrgetter".msg = "operator.attrge
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = """\
     typing.cast is banned: use explicit type narrowing or a typed variable instead.\
     """
+lint.flake8-type-checking.runtime-evaluated-decorators = [ "beartype.beartype" ]
 lint.pydocstyle.convention = "google"
 lint.preview = true
 

--- a/src/vws/_async_vws_request.py
+++ b/src/vws/_async_vws_request.py
@@ -5,8 +5,8 @@ Vuforia Target API.
 from beartype import BeartypeConf, beartype
 from vws_auth_tools import authorization_header, rfc_1123_date
 
-from vws.response import Response  # noqa: TC001
-from vws.transports import AsyncTransport  # noqa: TC001
+from vws.response import Response
+from vws.transports import AsyncTransport
 
 
 @beartype(conf=BeartypeConf(is_pep484_tower=True))

--- a/src/vws/_model_targets.py
+++ b/src/vws/_model_targets.py
@@ -2,7 +2,7 @@
 
 import base64
 import json
-from collections.abc import Sequence  # noqa: TC003
+from collections.abc import Sequence
 from http import HTTPStatus
 from typing import Any
 
@@ -18,13 +18,13 @@ from vws.exceptions.model_target_exceptions import (
     UnknownModelTargetDatasetError,
 )
 from vws.exceptions.vws_exceptions import TooManyRequestsError
-from vws.model_target_datasets import (  # noqa: TC001
+from vws.model_target_datasets import (
     ModelTargetDatasetType,
     ModelTargetModel,
     ModelTargetView,
 )
 from vws.reports import ModelTargetDatasetStatusReport
-from vws.response import Response  # noqa: TC001
+from vws.response import Response
 
 OAUTH2_TOKEN_PATH = "/oauth2/token"  # noqa: S105
 OAUTH2_TOKEN_BODY = b"grant_type=client_credentials"

--- a/src/vws/_reco_counts.py
+++ b/src/vws/_reco_counts.py
@@ -1,6 +1,6 @@
 """Internal helpers for the database reco counts report endpoints."""
 
-import calendar  # noqa: TC003
+import calendar
 import json
 from http import HTTPStatus
 
@@ -12,7 +12,7 @@ from vws.exceptions.custom_exceptions import (
     RecoCountsReportNotReadyError,
 )
 from vws.reports import RecoCountsReport
-from vws.response import Response  # noqa: TC001
+from vws.response import Response
 
 
 @beartype(conf=BeartypeConf(is_pep484_tower=True))

--- a/src/vws/_vws_request.py
+++ b/src/vws/_vws_request.py
@@ -5,8 +5,8 @@ API.
 from beartype import BeartypeConf, beartype
 from vws_auth_tools import authorization_header, rfc_1123_date
 
-from vws.response import Response  # noqa: TC001
-from vws.transports import Transport  # noqa: TC001
+from vws.response import Response
+from vws.transports import Transport
 
 
 @beartype(conf=BeartypeConf(is_pep484_tower=True))

--- a/src/vws/exceptions/model_target_exceptions.py
+++ b/src/vws/exceptions/model_target_exceptions.py
@@ -10,7 +10,7 @@ from typing import Any
 from beartype import beartype
 
 from vws.reports import ModelTargetGenerationDetail
-from vws.response import Response  # noqa: TC001
+from vws.response import Response
 
 
 @beartype

--- a/src/vws/model_target_datasets.py
+++ b/src/vws/model_target_datasets.py
@@ -4,7 +4,7 @@ See
 https://developer.vuforia.com/library/vuforia-engine/web-api/model-target-web-api/.
 """
 
-from collections.abc import Sequence  # noqa: TC003
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum, unique
 

--- a/src/vws/reports.py
+++ b/src/vws/reports.py
@@ -3,7 +3,7 @@
 import csv
 import datetime
 import io
-from collections.abc import Sequence  # noqa: TC003
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, unique
 from typing import Any, Self

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,9 @@
 """Configuration, plugins and fixtures for `pytest`."""
 
+from __future__ import annotations
+
 import datetime
-import io  # noqa: TC003
-from collections.abc import AsyncGenerator, Generator  # noqa: TC003
-from pathlib import Path  # noqa: TC003
-from typing import BinaryIO, Literal
+from typing import TYPE_CHECKING, BinaryIO, Literal
 
 import pytest
 import pytest_asyncio
@@ -28,6 +27,11 @@ from vws.model_target_datasets import (
     ModelTargetModel,
     ModelTargetView,
 )
+
+if TYPE_CHECKING:
+    import io
+    from collections.abc import AsyncGenerator, Generator
+    from pathlib import Path
 
 # The mock accepts one hard-coded pair of Model Target Web API OAuth2
 # credentials, which it does not expose.

--- a/tests/test_async_cloud_reco_exceptions.py
+++ b/tests/test_async_cloud_reco_exceptions.py
@@ -2,10 +2,12 @@
 AsyncCloudRecoService.
 """
 
-import io  # noqa: TC003
+from __future__ import annotations
+
 import json
 import uuid
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 
 import pytest
 from mock_vws import CloudQueryFailureResponse, MockVWS
@@ -22,6 +24,9 @@ from vws.exceptions.cloud_reco_exceptions import (
 from vws.exceptions.custom_exceptions import (
     RequestEntityTooLargeError,
 )
+
+if TYPE_CHECKING:
+    import io
 
 
 @pytest.mark.asyncio

--- a/tests/test_async_query.py
+++ b/tests/test_async_query.py
@@ -1,8 +1,9 @@
 """Tests for the ``AsyncCloudRecoService`` querying functionality."""
 
-import io  # noqa: TC003
+from __future__ import annotations
+
 import uuid
-from typing import BinaryIO
+from typing import TYPE_CHECKING, BinaryIO
 
 import pytest
 from mock_vws import MockVWS
@@ -10,6 +11,9 @@ from mock_vws.database import CloudDatabase
 
 from vws import AsyncCloudRecoService, AsyncVWS
 from vws.include_target_data import CloudRecoIncludeTargetData
+
+if TYPE_CHECKING:
+    import io
 
 
 class TestQuery:

--- a/tests/test_async_vws.py
+++ b/tests/test_async_vws.py
@@ -1,13 +1,13 @@
 """Tests for async helper functions for managing a Vuforia database."""
 
+from __future__ import annotations
+
 import base64
 import calendar
-import datetime  # noqa: TC003
-import io  # noqa: TC003
 import time
 import uuid
 from http import HTTPStatus
-from typing import BinaryIO
+from typing import TYPE_CHECKING, BinaryIO
 
 import pytest
 from mock_vws import MockVWS
@@ -32,6 +32,10 @@ from vws.reports import (
 )
 from vws.response import Response
 from vws.vumark_accept import VuMarkAccept
+
+if TYPE_CHECKING:
+    import datetime
+    import io
 
 
 class TestAddTarget:

--- a/tests/test_async_vws_exceptions.py
+++ b/tests/test_async_vws_exceptions.py
@@ -1,5 +1,7 @@
 """Tests for VWS exceptions raised from async clients."""
 
+from __future__ import annotations
+
 import base64
 import io
 import uuid
@@ -11,7 +13,6 @@ from mock_vws.database import CloudDatabase
 from mock_vws.states import States
 
 from vws import AsyncVuMarkService, AsyncVWS
-from vws.exceptions.base_exceptions import VWSError  # noqa: TC001
 from vws.exceptions.custom_exceptions import (
     ServerError,
 )
@@ -156,7 +157,9 @@ async def test_target_quota_reached(
 async def test_project_state_error(
     *,
     state: States,
-    expected_exception: type[VWSError],
+    expected_exception: type[
+        ProjectSuspendedError | ProjectHasNoAPIAccessError
+    ],
 ) -> None:
     """Configured project states raise their matching exceptions."""
     database = CloudDatabase(state=state)
@@ -414,7 +417,9 @@ async def test_invalid_instance_id(
 async def test_documented_vumark_error_codes(
     *,
     failure: VuMarkGenerationFailure,
-    exception_type: type[VWSError],
+    exception_type: type[
+        QuotaExceededError | LicenseCheckFailedError | AuthorizationFailedError
+    ],
     status_code: HTTPStatus,
 ) -> None:
     """Documented VuMark failures raise matching exceptions."""

--- a/tests/test_cloud_reco_exceptions.py
+++ b/tests/test_cloud_reco_exceptions.py
@@ -1,9 +1,11 @@
 """Tests for exceptions raised when using the CloudRecoService."""
 
-import io  # noqa: TC003
+from __future__ import annotations
+
 import json
 import uuid
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 
 import pytest
 from mock_vws import CloudQueryFailureResponse, MockVWS
@@ -22,6 +24,9 @@ from vws.exceptions.cloud_reco_exceptions import (
 from vws.exceptions.custom_exceptions import (
     RequestEntityTooLargeError,
 )
+
+if TYPE_CHECKING:
+    import io
 
 
 def test_too_many_max_results(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,12 +1,13 @@
 """Tests for the ``CloudRecoService`` querying functionality."""
 
+from __future__ import annotations
+
 import datetime
-import io  # noqa: TC003
 import json
 import secrets
 import uuid
 from http import HTTPStatus
-from typing import BinaryIO
+from typing import TYPE_CHECKING, BinaryIO
 
 import pytest
 import requests
@@ -17,6 +18,9 @@ from mock_vws.database import CloudDatabase
 from vws import VWS, CloudRecoService
 from vws.include_target_data import CloudRecoIncludeTargetData
 from vws.response import Response
+
+if TYPE_CHECKING:
+    import io
 
 
 class _JSONResponseTransport:

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,8 +1,10 @@
 """Tests for HTTP transport implementations."""
 
-import io  # noqa: TC003
+from __future__ import annotations
+
 import uuid
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 
 import httpx
 import httpx2
@@ -35,6 +37,9 @@ from vws.transports import (
     HTTPXTransport,
 )
 from vws.vumark_accept import VuMarkAccept
+
+if TYPE_CHECKING:
+    import io
 
 
 class TestHTTPXTransport:

--- a/tests/test_vws.py
+++ b/tests/test_vws.py
@@ -1,15 +1,16 @@
 """Tests for helper functions for managing a Vuforia database."""
 
+from __future__ import annotations
+
 import base64
 import calendar
 import datetime
-import io  # noqa: TC003
 import json
 import secrets
 import time
 import uuid
 from http import HTTPStatus
-from typing import BinaryIO
+from typing import TYPE_CHECKING, BinaryIO
 
 import pytest
 import requests
@@ -39,6 +40,9 @@ from vws.reports import (
 )
 from vws.response import Response
 from vws.vumark_accept import VuMarkAccept
+
+if TYPE_CHECKING:
+    import io
 
 
 class _JSONResponseTransport:


### PR DESCRIPTION
Ruff's type-checking rules did not know that annotations on directly beartype-decorated functions are evaluated at runtime. This configured that public decorator explicitly and removes the corresponding inline suppressions.

Test modules now postpone annotations and place genuinely type-only imports behind TYPE_CHECKING. Imports used by methods on class-decorated clients remain in place because beartype evaluates those annotations at runtime and Ruff does not model class decorators here.

Validation: full pre-commit and pre-push hook suites.
