### PR TITLE
Cover imported exception classes

### DIFF
--- a/src/vws/exceptions/custom_exceptions.py
+++ b/src/vws/exceptions/custom_exceptions.py
@@ -90,7 +90,7 @@ class RecoCountsReportTimeoutError(Exception):
 
 
 @beartype
-class ServerError(Exception):  # pragma: no cover
+class ServerError(Exception):
     """Exception raised when VWS returns a server error."""
 
     def __init__(self, response: Response) -> None:

--- a/src/vws/exceptions/vws_exceptions.py
+++ b/src/vws/exceptions/vws_exceptions.py
@@ -84,9 +84,8 @@ class TargetStatusProcessingError(VWSError):
         return _target_id_from_url(url=self.response.url)
 
 
-# This is not simulated by the mock.
 @beartype
-class DateRangeError(VWSError):  # pragma: no cover
+class DateRangeError(VWSError):
     """Exception raised when Vuforia returns a response with a result code
     'DateRangeError'.
     """
@@ -171,16 +170,14 @@ class TargetStatusNotSuccessError(VWSError):
 
 
 @beartype
-class TooManyRequestsError(VWSError):  # pragma: no cover
+class TooManyRequestsError(VWSError):
     """Exception raised when Vuforia returns a response with a result code
     'TooManyRequests'.
     """
 
 
-# This is not simulated by client code because the accept parameter uses
-# the VuMarkAccept enum, which only allows valid values.
 @beartype
-class InvalidAcceptHeaderError(VWSError):  # pragma: no cover
+class InvalidAcceptHeaderError(VWSError):
     """Exception raised when Vuforia returns a response with a result code
     ``InvalidAcceptHeader``.
     """
@@ -193,10 +190,8 @@ class InvalidInstanceIdError(VWSError):
     """
 
 
-# This is not simulated by client code because the request body
-# is always valid JSON when using this client.
 @beartype
-class BadRequestError(VWSError):  # pragma: no cover
+class BadRequestError(VWSError):
     """Exception raised when Vuforia returns a response with a result code
     ``BadRequest``.
     """


### PR DESCRIPTION
## Summary

- remove unnecessary coverage exclusions from five imported exception classes
- keep behavior unchanged; existing exception tests execute these definitions

## Validation

- `uv run prek run --all-files`
- `uv run prek run --all-files --hook-stage pre-push`
- `uv run --group=dev pytest -q --cov-fail-under=100 --cov=src/ --cov=tests .` (460 passed; 100% coverage)
