### PR TITLE
Remove covered VWS error-path exclusions

### DIFF
--- a/src/vws/async_vws.py
+++ b/src/vws/async_vws.py
@@ -148,9 +148,7 @@ class AsyncVWS:
             # The Vuforia API returns a 429 response with no JSON body.
             raise TooManyRequestsError(response=response)
 
-        if (
-            response.status_code >= HTTPStatus.INTERNAL_SERVER_ERROR
-        ):  # pragma: no cover
+        if response.status_code >= HTTPStatus.INTERNAL_SERVER_ERROR:
             raise ServerError(response=response)
 
         result_code = string_field(
@@ -343,7 +341,7 @@ class AsyncVWS:
                 return
 
             elapsed_time = asyncio.get_event_loop().time() - start_time
-            if elapsed_time > timeout_seconds:  # pragma: no cover
+            if elapsed_time > timeout_seconds:
                 raise TargetProcessingTimeoutError
 
             await asyncio.sleep(

--- a/src/vws/vws.py
+++ b/src/vws/vws.py
@@ -134,9 +134,7 @@ class VWS:
             # The Vuforia API returns a 429 response with no JSON body.
             raise TooManyRequestsError(response=response)
 
-        if (
-            response.status_code >= HTTPStatus.INTERNAL_SERVER_ERROR
-        ):  # pragma: no cover
+        if response.status_code >= HTTPStatus.INTERNAL_SERVER_ERROR:
             raise ServerError(response=response)
 
         result_code = string_field(
@@ -323,7 +321,7 @@ class VWS:
                 return
 
             elapsed_time = time.monotonic() - start_time
-            if elapsed_time > timeout_seconds:  # pragma: no cover
+            if elapsed_time > timeout_seconds:
                 raise TargetProcessingTimeoutError
 
             time.sleep(seconds_between_requests)


### PR DESCRIPTION
## Summary

- remove stale coverage exclusions from sync and async VWS server-error handling
- remove stale coverage exclusions from sync and async target-processing timeout handling
- retain the VWS rate-limit and VuMark exclusions, which the full coverage run confirmed are not exercised

The existing public client tests already execute all four changed branches; this makes the coverage report reflect that behavior without adding private-helper tests. This does not overlap #3225, which only changes exception class declarations.

## Validation

- `uv run --group=dev prek run --all-files --hook-stage pre-commit --no-fail-fast --verbose`
- `uv run --group=dev prek run --all-files --hook-stage pre-push --no-fail-fast --verbose`
- `uv run --group=dev prek run --all-files --hook-stage manual --no-fail-fast --verbose`
- `uv run --group=dev pytest -q --cov-fail-under 100 --cov=src/ --cov=tests/ .` (460 passed, 100% coverage)