### PR TITLE
Cover missing bodies in target-name errors

### DIFF
--- a/src/vws/exceptions/vws_exceptions.py
+++ b/src/vws/exceptions/vws_exceptions.py
@@ -143,7 +143,7 @@ class TargetNameExistError(VWSError):
     def target_name(self) -> str:
         """The target name which already exists."""
         response_body = self.response.request_body
-        if not isinstance(response_body, str | bytes):  # pragma: no cover
+        if not isinstance(response_body, str | bytes):
             msg = "A target-name error response must have a request body."
             raise TypeError(msg)
         request_json = json_object(value=response_body)

--- a/tests/test_vws_exceptions.py
+++ b/tests/test_vws_exceptions.py
@@ -241,6 +241,26 @@ def test_target_name_exist(
     assert exc.value.target_name == "x"
 
 
+def test_target_name_exist_requires_request_body() -> None:
+    """A target-name error without a request body is rejected."""
+    response = Response(
+        text="",
+        url="https://vws.vuforia.com/targets",
+        status_code=HTTPStatus.FORBIDDEN,
+        headers={},
+        request_body=None,
+        tell_position=0,
+        content=b"",
+    )
+    error = TargetNameExistError(response=response)
+
+    with pytest.raises(
+        expected_exception=TypeError,
+        match="must have a request body",
+    ):
+        _ = error.target_name
+
+
 def test_project_inactive(
     high_quality_image: io.BytesIO,
 ) -> None:


### PR DESCRIPTION
`TargetNameExistError.target_name` already rejects responses whose request
body is absent, but that public error-contract path was not tested and carried
a coverage exclusion.

This adds a public-interface test which constructs the documented response
value, accesses the exception property, and verifies its `TypeError`. The
existing successful duplicate-name tests continue to cover the valid-body
path, so the coverage pragma is no longer needed.

Validation:

- all pre-commit hooks
- all pre-push hooks, including mypy, Pyright, Ty, and Pyrefly
- full test suite: 467 passed
- coverage gate: 100.00%
