### PR TITLE
Move annotation-only conftest imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,11 @@
 """Setup for Sybil."""
 
-import io  # noqa: TC003
+from __future__ import annotations
+
 import uuid
-from collections.abc import Generator  # noqa: TC003
 from doctest import ELLIPSIS
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from mock_vws import MockVWS
@@ -15,6 +16,10 @@ from sybil.parsers.rest import (
     DocTestParser,
     PythonCodeBlockParser,
 )
+
+if TYPE_CHECKING:
+    import io
+    from collections.abc import Generator
 
 
 @pytest.fixture(name="make_image_file")


### PR DESCRIPTION
`conftest.py` imported `io` and `Generator` at runtime solely for fixture annotations and then suppressed Ruff's runtime-import diagnostics. Unlike the package service classes, this file is not class-decorated by Beartype, so those imports do not need to wait for Beartype 0.23.

Enable postponed annotation evaluation and move both imports behind `TYPE_CHECKING`. The fixture behavior is unchanged and the two `TC003` ignores are removed.

Validation:
- all configured pre-commit hooks
- all configured pre-push hooks
- all configured manual hooks
- full test suite: 467 passed
- coverage: 100.00%